### PR TITLE
Add ai-config JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ compliance_reports/
 Auto-generated audit & test outcome artifacts.
 
 5 · JSON Schemas
-A full JSON Schema for ai-config.json is provided in Appendix A for validation tooling.
+A full JSON Schema for ai-config.json is available in `ai-config.schema.json` (and reproduced in Appendix A). Validation tooling should reference this file when checking `.ai/0-ai-config/ai-config.json`.
 
 6 · Lifecycle Workflows
 For a detailed reference on the commands mentioned below, see Appendix C.
@@ -335,11 +335,13 @@ Purpose: Checks the /.ai/ directory for completeness, correctness, and adherence
 
 Usage: ai-validate [options]
 
+ai-validate looks for `ai-config.schema.json` at the repository root and uses it to verify `.ai/0-ai-config/ai-config.json`. Other JSON Schema tools can load the same file for standalone checks.
+
 Behavior: Runs a series of checks and exits with a non-zero status code if errors are found.
 
 Checks Performed:
 
-Schema Validation: Ensures ai-config.json conforms to the JSON Schema in Appendix A.
+Schema Validation: Ensures ai-config.json conforms to `ai-config.schema.json` (also shown in Appendix A).
 
 File Existence: Verifies that all Required files from the standard are present.
 

--- a/ai-config.schema.json
+++ b/ai-config.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "AI Config",
+  "type": "object",
+  "required": ["projectName", "description", "primaryLanguage", "aiPreferences"],
+  "properties": {
+    "projectName": { "type": "string", "minLength": 1 },
+    "description":  { "type": "string" },
+    "primaryLanguage": { "type": "string" },
+    "frameworks": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "license": { "type": "string" },
+    "aiPreferences": {
+      "type": "object",
+      "required": ["styleGuide", "testingFramework", "promptOnMissing"],
+      "properties": {
+        "styleGuide": { "type": "string" },
+        "testingFramework": { "type": "string" },
+        "promptOnMissing": { "type": "boolean" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- include full ai-config JSON schema as `ai-config.schema.json`
- reference the schema file in README
- document that `ai-validate` and other tools should load this schema

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bbf4a0f54832ea99c401b91ebf7c7