### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,6 @@ ai-migrate --from readme,license --interactive
 # Validate the directory
 ai-validate --level warn
 ```
-=======
 
 ## CLI Usage
 


### PR DESCRIPTION
## Summary
- remove stray divider line from README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bc6f4c094832e95571955491898f3