### PR TITLE
Add MCP endpoint script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,18 @@ Options:
 | --level <level> | Sets the reporting level. error (default): fails on any validation issue. warn: prints issues but always exits successfully. |
 | --check-links | Enables the optional (and potentially slow) validation of external links in Markdown files.                  |
 
+### gitmcp
+Purpose: Serves the `.ai` directory over HTTP via a simple MCP endpoint.
+
+Usage:
+```bash
+gitmcp --port 8000
+```
+
+The server returns a JSON payload of the `.ai` directory when requesting
+`http://localhost:8000/context`. Tools can fetch this endpoint to retrieve
+structured project context following the Model Context Protocol.
+
 
 CLI Installation
 The CLI tools can be installed from source using `pip`:
@@ -395,7 +407,7 @@ The CLI tools can be installed from source using `pip`:
 pip install .
 ```
 
-This exposes three commands: `ai-init`, `ai-migrate`, and `ai-validate`.
+This exposes four commands: `ai-init`, `ai-migrate`, `ai-validate`, and `gitmcp`.
 
 Example Usage
 ```
@@ -407,6 +419,9 @@ ai-migrate --from readme,license --interactive
 
 # Validate the directory
 ai-validate --level warn
+
+# Serve .ai over MCP
+gitmcp --port 8000
 ```
 
 Run `python -m ai_cli -h` to see all options.

--- a/ai_cli/gitmcp_cmd.py
+++ b/ai_cli/gitmcp_cmd.py
@@ -1,0 +1,49 @@
+import argparse
+import json
+import http.server
+from pathlib import Path
+
+
+def build_index():
+    base = Path('.ai')
+    result = {}
+    if not base.exists():
+        return result
+    for p in base.rglob('*'):
+        if p.is_file():
+            result[str(p.relative_to(base))] = p.read_text()
+    return result
+
+
+class MCPHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path not in ('/', '/context'):
+            self.send_response(404)
+            self.end_headers()
+            return
+        data = build_index()
+        body = json.dumps(data).encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description='Serve the .ai directory via a simple MCP endpoint'
+    )
+    parser.add_argument('--port', type=int, default=8000, help='Port to listen on')
+    args = parser.parse_args(argv)
+    server = http.server.ThreadingHTTPServer(('0.0.0.0', args.port), MCPHandler)
+    print(f'Serving .ai on port {args.port}')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
             'ai-init=ai_cli.init_cmd:main',
             'ai-migrate=ai_cli.migrate_cmd:main',
             'ai-validate=ai_cli.validate_cmd:main',
+            'gitmcp=ai_cli.gitmcp_cmd:main',
         ],
     },
 )

--- a/tests/test_gitmcp.py
+++ b/tests/test_gitmcp.py
@@ -1,0 +1,36 @@
+import json
+import os
+import tempfile
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import ai_cli.gitmcp_cmd as gitmcp
+
+
+def test_gitmcp_serves_ai_directory():
+    with tempfile.TemporaryDirectory() as tmp:
+        cwd = os.getcwd()
+        os.chdir(tmp)
+        try:
+            # prepare .ai directory
+            base = Path('.ai/1-context')
+            base.mkdir(parents=True, exist_ok=True)
+            context_file = base / 'project_context.md'
+            context_file.write_text('hello')
+
+            server = ThreadingHTTPServer(('127.0.0.1', 0), gitmcp.MCPHandler)
+            port = server.server_address[1]
+            t = threading.Thread(target=server.handle_request)
+            t.start()
+            try:
+                with urllib.request.urlopen(f'http://127.0.0.1:{port}/context') as resp:
+                    data = json.load(resp)
+                assert '1-context/project_context.md' in data
+                assert data['1-context/project_context.md'] == 'hello'
+            finally:
+                server.server_close()
+                t.join()
+        finally:
+            os.chdir(cwd)


### PR DESCRIPTION
## Summary
- expose `.ai` data through a simple gitmcp HTTP endpoint
- document gitmcp usage in README
- include gitmcp entry point in setup
- test serving of `.ai` via gitmcp

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd51dce64832ea9bb043be8d7f8bd