### PR TITLE
Fix README formatting for directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The specification covers:
 
 ## Directory Structure Overview
 
+```text
 .ai/
   ├── 0-ai-config/
   │   ├── ai-config.json
@@ -76,6 +77,7 @@ The specification covers:
   └── 4-acceptance/
       ├── acceptance_criteria.md
       └── compliance_reports/
+```
 
 Mandatory vs. Optional
 


### PR DESCRIPTION
## Summary
- format the `.ai` Directory Structure Overview section as a fenced code block so the tree displays properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cdde85654832e9c857751aecf51a9